### PR TITLE
Upgrade to lilypond 2.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@
 FROM debian:testing
 MAINTAINER Iskaron <mail@iskaron.de>
 
+ENV VERSION=2.22.0-1
+
 RUN apt-get update && apt-get install -y wget bzip2 ghostscript openssh-client git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
 
-ADD https://lilypond.org/download/binaries/linux-64/lilypond-2.20.0-1.linux-64.sh ./
-RUN chmod +x lilypond-2.20.0-1.linux-64.sh
-RUN ./lilypond-2.20.0-1.linux-64.sh --batch --prefix /root/stable
-RUN rm lilypond-2.20.0-1.linux-64.sh
+ADD https://lilypond.org/download/binaries/linux-64/lilypond-${VERSION}.linux-64.sh ./
+RUN chmod +x lilypond-${VERSION}.linux-64.sh
+RUN ./lilypond-${VERSION}.linux-64.sh --batch --prefix /root/stable
+RUN rm lilypond-${VERSION}.linux-64.sh
 COPY lilyfy.sh /root/stable/bin
 
 ENV PATH /root/stable/bin:$PATH


### PR DESCRIPTION
I've been using your docker image from dockerhub quite a lot lately. I just noticed there is a new release of Lilypond, and i would like to keep using the 'latest' version.

I don't think merging this will automatically deploy it to Dockerhub or did i miss something?